### PR TITLE
[feat] Dispute resolver trait

### DIFF
--- a/pallets/payment/Cargo.toml
+++ b/pallets/payment/Cargo.toml
@@ -36,4 +36,5 @@ std = [
 	'sp-runtime/std',
 	'scale-info/std',
 	'orml-traits/std',
+	'orml-tokens/std'
 ]

--- a/pallets/payment/Cargo.toml
+++ b/pallets/payment/Cargo.toml
@@ -35,6 +35,5 @@ std = [
 	'frame-system/std',
 	'sp-runtime/std',
 	'scale-info/std',
-	'orml-traits/std',
-	'orml-tokens/std'
+	'orml-traits/std',	
 ]

--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -91,11 +91,10 @@ pub mod pallet {
 			recipient: T::AccountId,
 			asset: AssetIdOf<T>,
 			amount: BalanceOf<T>,
-			resolver: Option<T::AccountId>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			<Self as PaymentHandler<T::AccountId, AssetIdOf<T>, BalanceOf<T>>>::create_payment(
-				who, recipient, asset, amount, resolver,
+				who, recipient, asset, amount,
 			)?;
 			Ok(().into())
 		}
@@ -167,12 +166,7 @@ pub mod pallet {
 			recipient: T::AccountId,
 			asset: AssetIdOf<T>,
 			amount: BalanceOf<T>,
-			resolver: Option<T::AccountId>,
 		) -> DispatchResult {
-			let resolver_account = match resolver {
-				Some(x) => x,
-				None => T::DisputeResolver::get_origin(),
-			};
 			Payment::<T>::try_mutate(
 				from.clone(),
 				recipient.clone(),
@@ -183,7 +177,7 @@ pub mod pallet {
 						amount,
 						incentive_amount,
 						state: PaymentState::Created,
-						resolver_account,
+						resolver_account: T::DisputeResolver::get_origin(),
 					});
 					match maybe_payment {
 						Some(x) => {

--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -136,11 +136,9 @@ pub mod pallet {
 			use PaymentState::*;
 			let who = ensure_signed(origin)?;
 			// ensure the caller is the assigned resolver
-			match Payment::<T>::get(from.clone(), recipient.clone()) {
-				Some(payment) =>
-					ensure!(&who == &payment.resolver_account, Error::<T>::InvalidAction),
-				None => (()), // better to throw descriptive error
-			};
+			if let Some(payment) = Payment::<T>::get(from.clone(), recipient.clone()) {
+				ensure!(who == payment.resolver_account, Error::<T>::InvalidAction)
+			}
 			// try to update the payment to new state
 			match new_state {
                 Cancelled => {

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -11,14 +11,15 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	Percent,
 };
+use virto_primitives::DisputeResolver;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type AccountId = u8;
 pub const PAYMENT_CREATOR: AccountId = 10;
 pub const PAYMENT_RECIPENT: AccountId = 11;
-pub const JUDGE_ONE: AccountId = 11;
 pub const CURRENCY_ID: u32 = 2;
+pub const RESOLVER_ACCOUNT: AccountId = 12;
 
 frame_support::construct_runtime!(
 	pub enum Test where
@@ -91,13 +92,10 @@ impl orml_tokens::Config for Test {
 	type DustRemovalWhitelist = MockDustRemovalWhitelist;
 }
 
-pub struct MockMembership;
-impl Contains<AccountId> for MockMembership {
-	fn contains(t: &AccountId) -> bool {
-		match t {
-			&JUDGE_ONE => true,
-			_ => false,
-		}
+pub struct MockDisputeResolver;
+impl DisputeResolver<AccountId> for MockDisputeResolver {
+	fn get_origin() -> AccountId {
+		RESOLVER_ACCOUNT
 	}
 }
 
@@ -108,7 +106,7 @@ parameter_types! {
 impl payment::Config for Test {
 	type Event = Event;
 	type Asset = Tokens;
-	type JudgeWhitelist = MockMembership;
+	type DisputeResolver = MockDisputeResolver;
 	type IncentivePercentage = IncentivePercentage;
 }
 

--- a/pallets/payment/src/tests.rs
+++ b/pallets/payment/src/tests.rs
@@ -16,7 +16,6 @@ fn test_create_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			20,
-			Some(RESOLVER_ACCOUNT)
 		));
 		assert_eq!(
 			PaymentStore::<Test>::get(PAYMENT_CREATOR, PAYMENT_RECIPENT),
@@ -39,13 +38,7 @@ fn test_create_payment_works() {
 
 		// the payment should not be overwritten
 		assert_noop!(
-			Payment::create(
-				Origin::signed(PAYMENT_CREATOR),
-				PAYMENT_RECIPENT,
-				CURRENCY_ID,
-				20,
-				Some(RESOLVER_ACCOUNT)
-			),
+			Payment::create(Origin::signed(PAYMENT_CREATOR), PAYMENT_RECIPENT, CURRENCY_ID, 20,),
 			crate::Error::<Test>::PaymentAlreadyInProcess
 		);
 
@@ -71,7 +64,6 @@ fn test_release_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
-			Some(RESOLVER_ACCOUNT)
 		));
 		assert_eq!(
 			PaymentStore::<Test>::get(PAYMENT_CREATOR, PAYMENT_RECIPENT),
@@ -128,7 +120,6 @@ fn test_cancel_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
-			Some(RESOLVER_ACCOUNT)
 		));
 		assert_eq!(
 			PaymentStore::<Test>::get(PAYMENT_CREATOR, PAYMENT_RECIPENT),
@@ -174,7 +165,6 @@ fn test_cancel_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
-			Some(RESOLVER_ACCOUNT)
 		));
 		// the payment amount should be reserved
 		assert_eq!(Tokens::free_balance(CURRENCY_ID, &PAYMENT_CREATOR), 16);
@@ -191,7 +181,6 @@ fn test_set_state_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
-			Some(RESOLVER_ACCOUNT)
 		));
 
 		// should fail for non whitelisted caller
@@ -235,7 +224,6 @@ fn test_set_state_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
-			Some(RESOLVER_ACCOUNT)
 		));
 
 		// should be able to cancel a payment

--- a/pallets/payment/src/tests.rs
+++ b/pallets/payment/src/tests.rs
@@ -16,6 +16,7 @@ fn test_create_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			20,
+			Some(RESOLVER_ACCOUNT)
 		));
 		assert_eq!(
 			PaymentStore::<Test>::get(PAYMENT_CREATOR, PAYMENT_RECIPENT),
@@ -23,7 +24,8 @@ fn test_create_payment_works() {
 				asset: CURRENCY_ID,
 				amount: 20,
 				incentive_amount: 2,
-				state: PaymentState::Created
+				state: PaymentState::Created,
+				resolver_account: RESOLVER_ACCOUNT
 			})
 		);
 		// the payment amount should be reserved correctly
@@ -37,7 +39,13 @@ fn test_create_payment_works() {
 
 		// the payment should not be overwritten
 		assert_noop!(
-			Payment::create(Origin::signed(PAYMENT_CREATOR), PAYMENT_RECIPENT, CURRENCY_ID, 20,),
+			Payment::create(
+				Origin::signed(PAYMENT_CREATOR),
+				PAYMENT_RECIPENT,
+				CURRENCY_ID,
+				20,
+				Some(RESOLVER_ACCOUNT)
+			),
 			crate::Error::<Test>::PaymentAlreadyInProcess
 		);
 
@@ -47,7 +55,8 @@ fn test_create_payment_works() {
 				asset: CURRENCY_ID,
 				amount: 20,
 				incentive_amount: 2,
-				state: PaymentState::Created
+				state: PaymentState::Created,
+				resolver_account: RESOLVER_ACCOUNT
 			})
 		);
 	});
@@ -62,6 +71,7 @@ fn test_release_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
+			Some(RESOLVER_ACCOUNT)
 		));
 		assert_eq!(
 			PaymentStore::<Test>::get(PAYMENT_CREATOR, PAYMENT_RECIPENT),
@@ -69,7 +79,8 @@ fn test_release_payment_works() {
 				asset: CURRENCY_ID,
 				amount: 40,
 				incentive_amount: 4,
-				state: PaymentState::Created
+				state: PaymentState::Created,
+				resolver_account: RESOLVER_ACCOUNT
 			})
 		);
 		// the payment amount should be reserved
@@ -96,7 +107,8 @@ fn test_release_payment_works() {
 				asset: CURRENCY_ID,
 				amount: 40,
 				incentive_amount: 4,
-				state: PaymentState::Cancelled
+				state: PaymentState::Cancelled,
+				resolver_account: RESOLVER_ACCOUNT
 			})
 		);
 		// cannot call cancel again
@@ -116,6 +128,7 @@ fn test_cancel_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
+			Some(RESOLVER_ACCOUNT)
 		));
 		assert_eq!(
 			PaymentStore::<Test>::get(PAYMENT_CREATOR, PAYMENT_RECIPENT),
@@ -123,7 +136,8 @@ fn test_cancel_payment_works() {
 				asset: CURRENCY_ID,
 				amount: 40,
 				incentive_amount: 4,
-				state: PaymentState::Created
+				state: PaymentState::Created,
+				resolver_account: RESOLVER_ACCOUNT
 			})
 		);
 		// the payment amount should be reserved
@@ -144,7 +158,8 @@ fn test_cancel_payment_works() {
 				asset: CURRENCY_ID,
 				amount: 40,
 				incentive_amount: 4,
-				state: PaymentState::Released
+				state: PaymentState::Released,
+				resolver_account: RESOLVER_ACCOUNT
 			})
 		);
 		// cannot call release again
@@ -159,6 +174,7 @@ fn test_cancel_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
+			Some(RESOLVER_ACCOUNT)
 		));
 		// the payment amount should be reserved
 		assert_eq!(Tokens::free_balance(CURRENCY_ID, &PAYMENT_CREATOR), 16);
@@ -175,6 +191,7 @@ fn test_set_state_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
+			Some(RESOLVER_ACCOUNT)
 		));
 
 		// should fail for non whitelisted caller
@@ -190,7 +207,7 @@ fn test_set_state_payment_works() {
 
 		// should be able to release a payment
 		assert_ok!(Payment::resolve(
-			Origin::signed(JUDGE_ONE),
+			Origin::signed(RESOLVER_ACCOUNT),
 			PAYMENT_CREATOR,
 			PAYMENT_RECIPENT,
 			PaymentState::Released
@@ -208,7 +225,8 @@ fn test_set_state_payment_works() {
 				asset: CURRENCY_ID,
 				amount: 40,
 				incentive_amount: 4,
-				state: PaymentState::Released
+				state: PaymentState::Released,
+				resolver_account: RESOLVER_ACCOUNT
 			})
 		);
 
@@ -217,14 +235,15 @@ fn test_set_state_payment_works() {
 			PAYMENT_RECIPENT,
 			CURRENCY_ID,
 			40,
+			Some(RESOLVER_ACCOUNT)
 		));
 
 		// should be able to cancel a payment
 		assert_ok!(Payment::resolve(
-			Origin::signed(JUDGE_ONE),
+			Origin::signed(RESOLVER_ACCOUNT),
 			PAYMENT_CREATOR,
 			PAYMENT_RECIPENT,
-			PaymentState::Cancelled
+			PaymentState::Cancelled,
 		));
 
 		// the payment amount should be transferred
@@ -239,7 +258,8 @@ fn test_set_state_payment_works() {
 				asset: CURRENCY_ID,
 				amount: 40,
 				incentive_amount: 4,
-				state: PaymentState::Cancelled
+				state: PaymentState::Cancelled,
+				resolver_account: RESOLVER_ACCOUNT
 			})
 		);
 	});

--- a/primitives/src/payment.rs
+++ b/primitives/src/payment.rs
@@ -5,11 +5,12 @@ use sp_runtime::DispatchResult;
 
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct PaymentDetail<Asset, Amount> {
+pub struct PaymentDetail<Asset, Amount, Account> {
 	pub asset: Asset,
 	pub amount: Amount,
 	pub incentive_amount: Amount,
 	pub state: PaymentState,
+	pub resolver_account: Account
 }
 
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
@@ -27,7 +28,7 @@ pub trait PaymentHandler<Account, Asset, Amount> {
 	/// Attempt to reserve an amount of the given asset from the caller
 	/// If not possible then return Error. Possible reasons for failure include:
 	/// - User does not have enough balance.
-	fn create_payment(from: Account, to: Account, asset: Asset, amount: Amount) -> DispatchResult;
+	fn create_payment(from: Account, to: Account, asset: Asset, amount: Amount, resolver: Option<Account>) -> DispatchResult;
 
 	/// Attempt to transfer an amount of the given asset from the given payment_id
 	/// If not possible then return Error. Possible reasons for failure include:
@@ -47,5 +48,11 @@ pub trait PaymentHandler<Account, Asset, Amount> {
 	/// Attempt to fetch the details of a payment from the given payment_id
 	/// Possible reasons for failure include:
 	/// - The payment does not exist
-	fn get_payment_details(from: Account, to: Account) -> Option<PaymentDetail<Asset, Amount>>;
+	fn get_payment_details(from: Account, to: Account) -> Option<PaymentDetail<Asset, Amount, Account>>;
+}
+
+/// DisputeResolver trait defines how to create/assing judges for solving payment disputes
+pub trait DisputeResolver<Account> {
+	/// Get a DisputeResolver (Judge) account
+	fn get_origin() -> Account;
 }

--- a/primitives/src/payment.rs
+++ b/primitives/src/payment.rs
@@ -28,13 +28,7 @@ pub trait PaymentHandler<Account, Asset, Amount> {
 	/// Attempt to reserve an amount of the given asset from the caller
 	/// If not possible then return Error. Possible reasons for failure include:
 	/// - User does not have enough balance.
-	fn create_payment(
-		from: Account,
-		to: Account,
-		asset: Asset,
-		amount: Amount,
-		resolver: Option<Account>,
-	) -> DispatchResult;
+	fn create_payment(from: Account, to: Account, asset: Asset, amount: Amount) -> DispatchResult;
 
 	/// Attempt to transfer an amount of the given asset from the given payment_id
 	/// If not possible then return Error. Possible reasons for failure include:

--- a/primitives/src/payment.rs
+++ b/primitives/src/payment.rs
@@ -10,7 +10,7 @@ pub struct PaymentDetail<Asset, Amount, Account> {
 	pub amount: Amount,
 	pub incentive_amount: Amount,
 	pub state: PaymentState,
-	pub resolver_account: Account
+	pub resolver_account: Account,
 }
 
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
@@ -28,7 +28,13 @@ pub trait PaymentHandler<Account, Asset, Amount> {
 	/// Attempt to reserve an amount of the given asset from the caller
 	/// If not possible then return Error. Possible reasons for failure include:
 	/// - User does not have enough balance.
-	fn create_payment(from: Account, to: Account, asset: Asset, amount: Amount, resolver: Option<Account>) -> DispatchResult;
+	fn create_payment(
+		from: Account,
+		to: Account,
+		asset: Asset,
+		amount: Amount,
+		resolver: Option<Account>,
+	) -> DispatchResult;
 
 	/// Attempt to transfer an amount of the given asset from the given payment_id
 	/// If not possible then return Error. Possible reasons for failure include:
@@ -48,7 +54,10 @@ pub trait PaymentHandler<Account, Asset, Amount> {
 	/// Attempt to fetch the details of a payment from the given payment_id
 	/// Possible reasons for failure include:
 	/// - The payment does not exist
-	fn get_payment_details(from: Account, to: Account) -> Option<PaymentDetail<Asset, Amount, Account>>;
+	fn get_payment_details(
+		from: Account,
+		to: Account,
+	) -> Option<PaymentDetail<Asset, Amount, Account>>;
 }
 
 /// DisputeResolver trait defines how to create/assing judges for solving payment disputes

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -63,7 +63,7 @@ mod proxy_type;
 use currency_id_convert::CurrencyIdConvert;
 use orml_traits::{arithmetic::Zero, parameter_type_with_key};
 use proxy_type::ProxyType;
-use virto_primitives::{Asset, Collateral as CollateralType};
+use virto_primitives::{Asset, Collateral as CollateralType, DisputeResolver};
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
@@ -652,6 +652,13 @@ impl orml_unknown_tokens::Config for Runtime {
 	type Event = Event;
 }
 
+pub struct VirtoDisputeResolver;
+impl DisputeResolver<AccountId> for VirtoDisputeResolver {
+	fn get_origin() -> AccountId {
+		Sudo::key()
+	}
+}
+
 parameter_types! {
 	pub const IncentivePercentage: Percent = Percent::from_percent(10);
 }
@@ -659,7 +666,7 @@ parameter_types! {
 impl virto_payment::Config for Runtime {
 	type Event = Event;
 	type Asset = Assets;
-	type JudgeWhitelist = Whitelist;
+	type DisputeResolver = VirtoDisputeResolver;
 	type IncentivePercentage = IncentivePercentage;
 }
 


### PR DESCRIPTION
This PR creates a new `resolver_account` field in PaymentDetail struct. This allows every new payment to select a resolver account if desired, if a resolver is not selected by the payment creator the `DisputeResolver` trait is used to determine a resolver for the payment.

Currently the `DisputeResolver` trait simply returns the root account, this can be improved in future to add more complex resolver selection logic.


Closes #143, #128