### PR TITLE
cleanup docs and tests

### DIFF
--- a/pallets/payment/README.md
+++ b/pallets/payment/README.md
@@ -86,7 +86,7 @@ The dispute resolver trait implements the logic to decide the dispute resolver o
 ```rust
 pub struct ExampleDisputeResolver;
 impl DisputeResolver<AccountId> for ExampleDisputeResolver {
-	fn get_origin() -> AccountId {
+	fn get_resolver_account() -> AccountId {
 		// Alice is the resolver account for all payment
 		Alice.to_account_id()
 	}

--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -510,7 +510,7 @@ pub mod pallet {
 						amount,
 						incentive_amount,
 						state: payment_state,
-						resolver_account: T::DisputeResolver::get_origin(),
+						resolver_account: T::DisputeResolver::get_resolver_account(),
 						fee_detail: None,
 					};
 

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -103,7 +103,7 @@ impl orml_tokens::Config for Test {
 
 pub struct MockDisputeResolver;
 impl crate::types::DisputeResolver<AccountId> for MockDisputeResolver {
-	fn get_origin() -> AccountId {
+	fn get_resolver_account() -> AccountId {
 		RESOLVER_ACCOUNT
 	}
 }

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -28,6 +28,9 @@ pub const CURRENCY_ID: Asset = Asset::Network(NetworkAsset::KSM);
 pub const RESOLVER_ACCOUNT: AccountId = 12;
 pub const FEE_RECIPIENT_ACCOUNT: AccountId = 20;
 pub const PAYMENT_RECIPENT_FEE_CHARGED: AccountId = 21;
+pub const INCENTIVE_PERCENTAGE: u8 = 10;
+pub const MARKETPLACE_FEE_PERCENTAGE: u8 = 10;
+pub const CANCEL_BLOCK_BUFFER: u64 = 600;
 
 frame_support::construct_runtime!(
 	pub enum Test where
@@ -117,16 +120,17 @@ impl crate::types::FeeHandler<Test> for MockFeeHandler {
 		_remark: Option<&[u8]>,
 	) -> (AccountId, Percent) {
 		match to {
-			&PAYMENT_RECIPENT_FEE_CHARGED => (FEE_RECIPIENT_ACCOUNT, Percent::from_percent(10)),
+			&PAYMENT_RECIPENT_FEE_CHARGED =>
+				(FEE_RECIPIENT_ACCOUNT, Percent::from_percent(MARKETPLACE_FEE_PERCENTAGE)),
 			_ => (FEE_RECIPIENT_ACCOUNT, Percent::from_percent(0)),
 		}
 	}
 }
 
 parameter_types! {
-	pub const IncentivePercentage: Percent = Percent::from_percent(10);
+	pub const IncentivePercentage: Percent = Percent::from_percent(INCENTIVE_PERCENTAGE);
 	pub const MaxRemarkLength: u32 = 50;
-	pub const CancelBufferBlockLength: u64 = 600;
+	pub const CancelBufferBlockLength: u64 = CANCEL_BLOCK_BUFFER;
 }
 
 impl payment::Config for Test {

--- a/pallets/payment/src/types.rs
+++ b/pallets/payment/src/types.rs
@@ -86,10 +86,10 @@ pub trait PaymentHandler<T: pallet::Config> {
 	fn get_payment_details(from: &T::AccountId, to: &T::AccountId) -> Option<PaymentDetail<T>>;
 }
 
-/// DisputeResolver trait defines how to create/assing judges for solving payment disputes
+/// DisputeResolver trait defines how to create/assign judges for solving payment disputes
 pub trait DisputeResolver<Account> {
-	/// Get a DisputeResolver (Judge) account
-	fn get_origin() -> Account;
+	/// Returns an `Account`
+	fn get_resolver_account() -> Account;
 }
 
 /// Fee Handler trait that defines how to handle marketplace fees to every payment/swap
@@ -103,15 +103,19 @@ pub trait FeeHandler<T: pallet::Config> {
 	) -> (T::AccountId, Percent);
 }
 
+/// Types of Tasks that can be scheduled in the pallet
 #[derive(PartialEq, Eq, Clone, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 pub enum Task {
 	// payment `from` to `to` has to be cancelled
 	Cancel,
 }
 
+/// The details of a scheduled task
 #[derive(PartialEq, Eq, Clone, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 pub struct ScheduledTask<Time: HasCompact> {
+	/// the type of scheduled task
 	pub task: Task,
+	/// the 'time' at which the task should be executed
 	#[codec(compact)]
 	pub when: Time,
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -461,7 +461,7 @@ impl orml_unknown_tokens::Config for Runtime {
 
 pub struct VirtoDisputeResolver;
 impl virto_payment::DisputeResolver<AccountId> for VirtoDisputeResolver {
-	fn get_origin() -> AccountId {
+	fn get_resolver_account() -> AccountId {
 		Sudo::key().expect("Sudo key not set!")
 	}
 }


### PR DESCRIPTION
- use constants to make tests more readable
- minor renaming and doc comments