### PR TITLE
New WeightToFee implementation.

### DIFF
--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -106,9 +106,15 @@ pub mod pallet {
 			);
 
 			// register asset_id => asset_multi_location
+<<<<<<< HEAD
 			AssetIdMultiLocation::<T>::insert(asset_id.clone(), asset_multi_location);
 			// register asset_multi_location => asset_id
 			AssetMultiLocationId::<T>::insert(asset_multi_location, asset_id.clone());
+=======
+			AssetIdMultiLocation::<T>::insert(asset_id.clone(), &asset_multi_location);
+			// register asset_multi_location => asset_id
+			AssetMultiLocationId::<T>::insert(&asset_multi_location, asset_id.clone());
+>>>>>>> nicof-add-new-weight-to-fee
 
 			Self::deposit_event(Event::ReserveAssetRegistered {
 				asset_id,

--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -106,9 +106,9 @@ pub mod pallet {
 			);
 
 			// register asset_id => asset_multi_location
-			AssetIdMultiLocation::<T>::insert(asset_id.clone(), &asset_multi_location);
+			AssetIdMultiLocation::<T>::insert(asset_id.clone(), asset_multi_location);
 			// register asset_multi_location => asset_id
-			AssetMultiLocationId::<T>::insert(&asset_multi_location, asset_id.clone());
+			AssetMultiLocationId::<T>::insert(asset_multi_location, asset_id.clone());
 
 			Self::deposit_event(Event::ReserveAssetRegistered {
 				asset_id,

--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -106,15 +106,9 @@ pub mod pallet {
 			);
 
 			// register asset_id => asset_multi_location
-<<<<<<< HEAD
-			AssetIdMultiLocation::<T>::insert(asset_id.clone(), asset_multi_location);
-			// register asset_multi_location => asset_id
-			AssetMultiLocationId::<T>::insert(asset_multi_location, asset_id.clone());
-=======
 			AssetIdMultiLocation::<T>::insert(asset_id.clone(), &asset_multi_location);
 			// register asset_multi_location => asset_id
 			AssetMultiLocationId::<T>::insert(&asset_multi_location, asset_id.clone());
->>>>>>> nicof-add-new-weight-to-fee
 
 			Self::deposit_event(Event::ReserveAssetRegistered {
 				asset_id,


### PR DESCRIPTION
This PR adds a new `WeightToFee` implementation that also brings in calculation the new proof size of the `Weights` v2.

In a basis this is the rule that conducts the conversion:

```rust
			// Take the maximum instead of the sum to charge by the more scarce resource.
			time_poly
				.eval(weight.ref_time())
				.max(proof_poly.eval(weight.proof_size()))
		}
```

Also this definition is aligned with the definition of common good parachain asset hub.