### PR TITLE
Add `kreivo-runtime` & `virto-runtime` build features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [profile.release]
 panic = 'unwind'
 
+[profile.production]
+inherits = "release"
+lto = true
+codegen-units = 1
+
 [workspace]
 members = [
     'node',

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -22,8 +22,8 @@ serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 
 # Local
-virto-runtime = { path = "../runtime/virto"}
-kreivo-runtime = { path = "../runtime/kreivo"}
+virto-runtime = { path = "../runtime/virto", optional = true}
+kreivo-runtime = { path = "../runtime/kreivo", optional = true}
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 
 # Substrate
@@ -97,13 +97,13 @@ wait-timeout = "0.2"
 polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.43" }
 
 [features]
-default = []
+default = ["virto-runtime", "kreivo-runtime"]
 runtime-benchmarks = [
-	"virto-runtime/runtime-benchmarks",
-	"kreivo-runtime/runtime-benchmarks",
+	"virto-runtime?/runtime-benchmarks",
+	"kreivo-runtime?/runtime-benchmarks",
 	"polkadot-cli/runtime-benchmarks"
 ]
 try-runtime = [
-	"virto-runtime/try-runtime",
-	"kreivo-runtime/try-runtime"
+	"virto-runtime?/try-runtime",
+	"kreivo-runtime?/try-runtime"
 ]

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -24,6 +24,7 @@ impl<RuntimeApi> RemarkBuilder<RuntimeApi> {
 	}
 }
 
+#[cfg(feature = "kreivo-runtime")]
 impl frame_benchmarking_cli::ExtrinsicBuilder for RemarkBuilder<kreivo_runtime::RuntimeApi> {
 	fn pallet(&self) -> &str {
 		"system"
@@ -84,6 +85,7 @@ impl frame_benchmarking_cli::ExtrinsicBuilder for RemarkBuilder<kreivo_runtime::
 	}
 }
 
+#[cfg(feature = "virto-runtime")]
 impl frame_benchmarking_cli::ExtrinsicBuilder for RemarkBuilder<virto_runtime::RuntimeApi> {
 	fn pallet(&self) -> &str {
 		"system"

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -20,7 +20,10 @@ use serde::{Deserialize, Serialize};
 use sp_core::{Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
+#[cfg(feature = "kreivo-runtime")]
 pub mod kreivo;
+
+#[cfg(feature = "virto-runtime")]
 pub mod virto;
 
 /// The default XCM version to set in genesis config.

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -29,6 +29,7 @@ use cumulus_primitives_core::{
 	ParaId,
 };
 use cumulus_relay_chain_interface::RelayChainInterface;
+
 use sp_core::Pair;
 
 use jsonrpsee::RpcModule;
@@ -72,15 +73,12 @@ type ParachainBackend = TFullBackend<Block>;
 
 type ParachainBlockImport<RuntimeApi> =
 	TParachainBlockImport<Block, Arc<ParachainClient<RuntimeApi>>, ParachainBackend>;
-pub struct KreivoRuntimeExecutor;
-impl sc_executor::NativeExecutionDispatch for KreivoRuntimeExecutor {
-	/// Only enable the benchmarking host functions when we actually want to
-	/// benchmark.
-	#[cfg(feature = "runtime-benchmarks")]
+
+pub struct RuntimeExecutor<Runtime>(PhantomData<Runtime>);
+
+#[cfg(feature = "kreivo-runtime")]
+impl sc_executor::NativeExecutionDispatch for RuntimeExecutor<kreivo_runtime::Runtime> {
 	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
-	/// Otherwise we only use the default Substrate host functions.
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	type ExtendHostFunctions = ();
 
 	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
 		kreivo_runtime::api::dispatch(method, data)
@@ -91,16 +89,9 @@ impl sc_executor::NativeExecutionDispatch for KreivoRuntimeExecutor {
 	}
 }
 
-/// Native executor instance.
-pub struct VirtoRuntimeExecutor;
-impl sc_executor::NativeExecutionDispatch for VirtoRuntimeExecutor {
-	/// Only enable the benchmarking host functions when we actually want to
-	/// benchmark.
-	#[cfg(feature = "runtime-benchmarks")]
+#[cfg(feature = "virto-runtime")]
+impl sc_executor::NativeExecutionDispatch for RuntimeExecutor<virto_runtime::Runtime> {
 	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
-	/// Otherwise we only use the default Substrate host functions.
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	type ExtendHostFunctions = ();
 
 	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
 		virto_runtime::api::dispatch(method, data)

--- a/virto-xcm-emulator/Cargo.lock
+++ b/virto-xcm-emulator/Cargo.lock
@@ -393,11 +393,31 @@ name = "assets-common"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "frame-support",
  "log",
  "pallet-xcm",
- "parachains-common",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-std",
+ "substrate-wasm-builder",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
+]
+
+[[package]]
+name = "assets-common"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "frame-support",
+ "log",
+ "pallet-xcm",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
@@ -744,17 +764,17 @@ dependencies = [
 [[package]]
 name = "bridge-hub-kusama-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
- "cumulus-primitives-utility",
+ "cumulus-pallet-aura-ext 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-dmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-session-benchmarking 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcm 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-timestamp 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -765,7 +785,7 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "pallet-multisig",
  "pallet-session",
  "pallet-timestamp",
@@ -773,8 +793,8 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
  "pallet-xcm",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -803,17 +823,17 @@ dependencies = [
 [[package]]
 name = "bridge-hub-polkadot-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
- "cumulus-primitives-utility",
+ "cumulus-pallet-aura-ext 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-dmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-session-benchmarking 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcm 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-timestamp 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -823,7 +843,7 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "pallet-multisig",
  "pallet-session",
  "pallet-timestamp",
@@ -831,8 +851,8 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
  "pallet-xcm",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -1223,17 +1243,17 @@ dependencies = [
 [[package]]
 name = "collectives-polkadot-runtime"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
- "cumulus-primitives-utility",
+ "cumulus-pallet-aura-ext 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-dmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-session-benchmarking 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcm 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-timestamp 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -1244,7 +1264,7 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "pallet-collective",
  "pallet-multisig",
  "pallet-preimage",
@@ -1258,8 +1278,8 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
  "pallet-xcm",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -1700,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1715,11 +1735,11 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -1738,12 +1758,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "dyn-clone",
  "futures",
  "log",
@@ -1764,12 +1784,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "futures",
  "parking_lot 0.12.1",
  "sc-consensus",
@@ -1787,10 +1807,10 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "async-trait",
- "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "futures",
  "futures-timer",
  "parity-scale-codec",
@@ -1810,11 +1830,11 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "futures",
  "futures-timer",
  "parity-scale-codec",
@@ -1834,16 +1854,16 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "cumulus-relay-chain-inprocess-interface",
- "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "cumulus-relay-chain-minimal-node",
  "futures",
  "polkadot-primitives",
@@ -1883,11 +1903,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-pallet-aura-ext"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-aura",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-consensus-aura",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+]
+
+[[package]]
+name = "cumulus-pallet-dmp-queue"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-support",
  "frame-system",
  "log",
@@ -1905,9 +1958,38 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
  "bytes",
- "cumulus-pallet-parachain-system-proc-macro",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system-proc-macro 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "environmental",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "polkadot-parachain",
+ "scale-info",
+ "sp-core",
+ "sp-externalities",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+ "sp-version",
+ "xcm",
+]
+
+[[package]]
+name = "cumulus-pallet-parachain-system"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "bytes",
+ "cumulus-pallet-parachain-system-proc-macro 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "environmental",
  "frame-support",
  "frame-system",
@@ -1940,9 +2022,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-pallet-parachain-system-proc-macro"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.22",
+]
+
+[[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-session",
+ "parity-scale-codec",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "cumulus-pallet-session-benchmarking"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1957,7 +2063,23 @@ name = "cumulus-pallet-xcm"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+]
+
+[[package]]
+name = "cumulus-pallet-xcm"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -1973,7 +2095,27 @@ name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "polkadot-runtime-common",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
+name = "cumulus-pallet-xcmp-queue"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-support",
  "frame-system",
  "log",
@@ -2006,14 +2148,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-primitives-core"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "scale-info",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
+ "xcm",
+]
+
+[[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "parity-scale-codec",
+ "sc-client-api",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-storage",
+ "sp-trie",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-primitives-parachain-inherent"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
@@ -2033,7 +2215,20 @@ name = "cumulus-primitives-timestamp"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "futures",
+ "parity-scale-codec",
+ "sp-inherents",
+ "sp-std",
+ "sp-timestamp",
+]
+
+[[package]]
+name = "cumulus-primitives-timestamp"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "futures",
  "parity-scale-codec",
  "sp-inherents",
@@ -2046,7 +2241,25 @@ name = "cumulus-primitives-utility"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "frame-support",
+ "log",
+ "parity-scale-codec",
+ "polkadot-runtime-common",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
+]
+
+[[package]]
+name = "cumulus-primitives-utility"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-support",
  "log",
  "parity-scale-codec",
@@ -2062,11 +2275,11 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "futures",
  "futures-timer",
  "polkadot-cli",
@@ -2090,7 +2303,25 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "futures",
+ "jsonrpsee-core",
+ "parity-scale-codec",
+ "polkadot-overseer",
+ "sc-client-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-state-machine",
+ "thiserror",
+]
+
+[[package]]
+name = "cumulus-relay-chain-interface"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "futures",
  "jsonrpsee-core",
  "parity-scale-codec",
@@ -2105,12 +2336,12 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "array-bytes 6.1.0",
  "async-trait",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "cumulus-relay-chain-rpc-interface",
  "futures",
  "lru 0.9.0",
@@ -2143,11 +2374,11 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "futures",
  "futures-timer",
  "jsonrpsee",
@@ -2175,7 +2406,20 @@ name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+]
+
+[[package]]
+name = "cumulus-test-relay-sproof-builder"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-runtime",
@@ -2186,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-validation-worker-provider"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "polkadot-node-core-pvf-worker",
  "toml 0.7.5",
@@ -2195,11 +2439,11 @@ dependencies = [
 [[package]]
 name = "cumulus-test-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
- "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-timestamp 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -2227,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "async-trait",
  "clap",
@@ -2237,10 +2481,10 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-pov-recovery",
  "cumulus-client-service",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "cumulus-relay-chain-inprocess-interface",
- "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-interface 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "cumulus-relay-chain-minimal-node",
  "cumulus-test-relay-validation-worker-provider",
  "cumulus-test-runtime",
@@ -2248,7 +2492,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "jsonrpsee",
  "pallet-transaction-payment",
- "parachains-common",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "polkadot-cli",
  "polkadot-node-subsystem",
@@ -4127,12 +4371,12 @@ dependencies = [
 [[package]]
 name = "integration-tests-common"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "bridge-hub-kusama-runtime",
  "bridge-hub-polkadot-runtime",
  "collectives-polkadot-runtime",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-support",
  "frame-system",
  "kusama-runtime",
@@ -4142,8 +4386,8 @@ dependencies = [
  "pallet-im-online",
  "pallet-staking",
  "pallet-xcm",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "penpal-runtime",
  "polkadot-core-primitives",
@@ -4435,16 +4679,16 @@ dependencies = [
 name = "kreivo-runtime"
 version = "0.4.0"
 dependencies = [
- "assets-common",
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
- "cumulus-primitives-utility",
+ "assets-common 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-aura-ext 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-dmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-session-benchmarking 3.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-xcm 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-xcmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-primitives-timestamp 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -4458,7 +4702,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-balances",
  "pallet-burner",
- "pallet-collator-selection",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "pallet-lockdown-mode",
  "pallet-multisig",
  "pallet-proxy",
@@ -4470,8 +4714,8 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-xcm",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -6224,6 +6468,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-collator-selection"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43#5e49f6e44820affccaf517fd22af564f4b495d40"
@@ -6427,7 +6690,7 @@ dependencies = [
 name = "pallet-lockdown-mode"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6986,7 +7249,19 @@ name = "parachain-info"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "parachain-info"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -6998,14 +7273,41 @@ name = "parachains-common"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
 dependencies = [
- "cumulus-primitives-utility",
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "frame-support",
  "frame-system",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "scale-info",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "substrate-wasm-builder",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
+]
+
+[[package]]
+name = "parachains-common"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
+dependencies = [
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "frame-support",
+ "frame-system",
+ "pallet-asset-tx-payment",
+ "pallet-assets",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "polkadot-primitives",
  "scale-info",
@@ -7190,17 +7492,17 @@ dependencies = [
 [[package]]
 name = "penpal-runtime"
 version = "0.9.27"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
- "cumulus-primitives-utility",
+ "cumulus-pallet-aura-ext 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-dmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-session-benchmarking 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcm 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-timestamp 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -7211,15 +7513,15 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-xcm",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "polkadot-parachain",
  "polkadot-primitives",
@@ -11904,18 +12206,18 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "statemine-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
- "assets-common",
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
- "cumulus-primitives-utility",
+ "assets-common 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-aura-ext 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-dmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-session-benchmarking 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcm 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-timestamp 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -11928,7 +12230,7 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "pallet-multisig",
  "pallet-nfts",
  "pallet-nfts-runtime-api",
@@ -11941,8 +12243,8 @@ dependencies = [
  "pallet-uniques",
  "pallet-utility",
  "pallet-xcm",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -11970,18 +12272,18 @@ dependencies = [
 [[package]]
 name = "statemint-runtime"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
- "assets-common",
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
- "cumulus-primitives-utility",
+ "assets-common 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-aura-ext 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-dmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-session-benchmarking 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcm 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-timestamp 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -11992,7 +12294,7 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "pallet-multisig",
  "pallet-nfts",
  "pallet-nfts-runtime-api",
@@ -12004,8 +12306,8 @@ dependencies = [
  "pallet-uniques",
  "pallet-utility",
  "pallet-xcm",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -13114,15 +13416,15 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 name = "virto-common"
 version = "0.1.0"
 dependencies = [
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
- "cumulus-primitives-utility",
+ "cumulus-pallet-aura-ext 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-dmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-session-benchmarking 3.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-xcm 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-pallet-xcmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-primitives-timestamp 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "cumulus-primitives-utility 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -13134,7 +13436,7 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
+ "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "pallet-lockdown-mode",
  "pallet-session",
  "pallet-sudo",
@@ -13143,8 +13445,8 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-xcm",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -13182,7 +13484,7 @@ dependencies = [
  "pallet-assets",
  "pallet-balances",
  "pallet-xcm",
- "parachains-common",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43)",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -14257,23 +14559,23 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.43#b8999fce0f61fb757f9e57e326cda48e70137019"
+source = "git+https://github.com/paritytech/cumulus?branch=release-v0.9.430#64c2fb8a60fde6ca90f140a88d17120e0fa180b2"
 dependencies = [
  "casey",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-pallet-dmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-pallet-xcmp-queue 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "cumulus-test-service",
  "frame-support",
  "frame-system",
  "log",
  "pallet-balances",
  "pallet-message-queue",
- "parachain-info",
- "parachains-common",
+ "parachain-info 0.1.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
+ "parachains-common 1.0.0 (git+https://github.com/paritytech/cumulus?branch=release-v0.9.430)",
  "parity-scale-codec",
  "paste",
  "polkadot-primitives",

--- a/virto-xcm-emulator/Cargo.toml
+++ b/virto-xcm-emulator/Cargo.toml
@@ -29,13 +29,13 @@ pallet-xcm = { default-features = false, git = "https://github.com/paritytech/po
 
 # Cumulus
 parachains-common = {  default-features = false,git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.43" }
-statemine-runtime = {  default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.43" }
+statemine-runtime = {  default-features = false, git = "https://github.com/paritytech/cumulus", branch = "release-v0.9.430" }
 kusama-runtime = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.43" }
 
 
 # Local
-xcm-emulator = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.43" }
-integration-tests-common = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.43" }
+xcm-emulator = { git = "https://github.com/paritytech/cumulus", branch = "release-v0.9.430" }
+integration-tests-common = { git = "https://github.com/paritytech/cumulus", branch = "release-v0.9.430" }
 
 kreivo-runtime = { path = "../runtime/kreivo"}
 

--- a/virto-xcm-emulator/src/tests/reserve_transfer.rs
+++ b/virto-xcm-emulator/src/tests/reserve_transfer.rs
@@ -48,21 +48,21 @@ fn reserve_transfer_native_token_from_relay_chain_to_kreivo_parachain() {
 
 		type RuntimeEvent = <Kusama as Relay>::RuntimeEvent;
 
-		assert_expected_events!(
+/* 		assert_expected_events!(
 			Kusama,
 			vec![
 				RuntimeEvent::XcmPallet(pallet_xcm::Event::Attempted(Outcome::Complete(weight))) => {
 					weight: weight_within_threshold((REF_TIME_THRESHOLD, PROOF_SIZE_THRESHOLD), Weight::from_parts(754_244_000, 0), *weight),
 				},
 			]
-		);
+		); */
 	});
 
 	// Receive XCM message in parachain
 	Kreivo::execute_with(|| {
 		type RuntimeEvent = <Kreivo as Para>::RuntimeEvent;
 
-		assert_expected_events!(
+/* 		assert_expected_events!(
 			Kreivo,
 			vec![
 				RuntimeEvent::DmpQueue(cumulus_pallet_dmp_queue::Event::ExecutedDownward {
@@ -70,7 +70,7 @@ fn reserve_transfer_native_token_from_relay_chain_to_kreivo_parachain() {
 					..
 				}) => {},
 			]
-		);
+		); */
 	});
 	const EST_FEES: u128 = 1_600_000_000 * 10;
 
@@ -197,21 +197,12 @@ fn reserve_transfer_asset_from_statemine_parachain_to_kreivo_parachain() {
 				weight_limit,
 			)
 		);
-
-		for event in Statemine::events() {
-			println!("Statemine event: {event:?}");
-		}
 	});
 
 	Kreivo::execute_with(|| {
 		type RuntimeEvent = <Kreivo as Para>::RuntimeEvent;
 
 		let balance = <Kreivo as KreivoPallet>::Assets::balance(ASSET_ID, KreivoReceiver::get());
-
-		for event in Kreivo::events() {
-			println!("Kreivo event: {event:?}");
-		}
-
 		assert_balance(balance, AMOUNT, 0);
 	});
 }

--- a/virto-xcm-emulator/src/tests/reserve_transfer.rs
+++ b/virto-xcm-emulator/src/tests/reserve_transfer.rs
@@ -48,21 +48,21 @@ fn reserve_transfer_native_token_from_relay_chain_to_kreivo_parachain() {
 
 		type RuntimeEvent = <Kusama as Relay>::RuntimeEvent;
 
-/* 		assert_expected_events!(
+		assert_expected_events!(
 			Kusama,
 			vec![
 				RuntimeEvent::XcmPallet(pallet_xcm::Event::Attempted(Outcome::Complete(weight))) => {
 					weight: weight_within_threshold((REF_TIME_THRESHOLD, PROOF_SIZE_THRESHOLD), Weight::from_parts(754_244_000, 0), *weight),
 				},
 			]
-		); */
+		);
 	});
 
 	// Receive XCM message in parachain
 	Kreivo::execute_with(|| {
 		type RuntimeEvent = <Kreivo as Para>::RuntimeEvent;
 
-/* 		assert_expected_events!(
+		assert_expected_events!(
 			Kreivo,
 			vec![
 				RuntimeEvent::DmpQueue(cumulus_pallet_dmp_queue::Event::ExecutedDownward {
@@ -70,7 +70,7 @@ fn reserve_transfer_native_token_from_relay_chain_to_kreivo_parachain() {
 					..
 				}) => {},
 			]
-		); */
+		);
 	});
 	const EST_FEES: u128 = 1_600_000_000 * 10;
 


### PR DESCRIPTION
Closes #272 

To review after #276 and #274 are merged.

This PR is adding the `kreivo-runtime` & `virto-runtime` build features that allows more optimized builds choosing specific runtimes builds.

@olanod , CI pipelines can be enhanced by choosing only `kreivo-runtime` option.