### PR TITLE
Feat add benchmarks payments

### DIFF
--- a/pallets/payments/Cargo.toml
+++ b/pallets/payments/Cargo.toml
@@ -32,7 +32,10 @@ pallet-scheduler= { workspace = true }
 
 [features]
 default = ["std"]
-runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
+runtime-benchmarks = [
+	"frame-benchmarking/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks"
+]
 std = [
 	"parity-scale-codec/std",
 	"scale-info/std",

--- a/pallets/payments/src/benchmarking.rs
+++ b/pallets/payments/src/benchmarking.rs
@@ -9,8 +9,9 @@ use frame_support::{
 	},
 	BoundedVec,
 };
-use frame_system::Origin;
+
 use frame_system::RawOrigin;
+use sp_runtime::Percent;
 
 const SEED: u32 = 1;
 
@@ -24,11 +25,13 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
-fn create_accounts<T: Config>() -> (T::AccountId, T::AccountId, AccountIdLookupOf<T>) {
-	let sender: T::AccountId = account("Alice", 0, 1);
-	let beneficiary: T::AccountId = account("Bob", 0, 2);
+fn create_accounts<T: Config>() -> (T::AccountId, T::AccountId, AccountIdLookupOf<T>, AccountIdLookupOf<T>) {
+	let sender: T::AccountId = account("Alice", 0, 10);
+	let beneficiary: T::AccountId = account("Bob", 0, 11);
+	let sender_lookup = T::Lookup::unlookup(sender.clone());
 	let beneficiary_lookup = T::Lookup::unlookup(beneficiary.clone());
-	(sender, beneficiary, beneficiary_lookup)
+
+	(sender, beneficiary, sender_lookup, beneficiary_lookup)
 }
 
 fn create_and_mint_asset<T: Config>(
@@ -48,8 +51,17 @@ fn create_payment<T: Config>(
 	amount: &BalanceOf<T>,
 	asset: &AssetIdOf<T>,
 	remark: Option<BoundedDataOf<T>>,
-) -> Result<(T::PaymentId, T::AccountId, T::AccountId, AccountIdLookupOf<T>), BenchmarkError> {
-	let (sender, beneficiary, beneficiary_lookup) = create_accounts::<T>();
+) -> Result<
+	(
+		T::PaymentId,
+		T::AccountId,
+		T::AccountId,
+		AccountIdLookupOf<T>,
+		AccountIdLookupOf<T>,
+	),
+	BenchmarkError,
+> {
+	let (sender, beneficiary, sender_lookup, beneficiary_lookup) = create_accounts::<T>();
 	create_and_mint_asset::<T>(&sender, &beneficiary, &asset, &<BalanceOf<T>>::from(100000u32))?;
 
 	let payment_id: T::PaymentId = Payments::<T>::next_payment_id()?;
@@ -69,7 +81,7 @@ fn create_payment<T: Config>(
 
 	// TODO: check storage items
 
-	Ok((payment_id, sender, beneficiary, beneficiary_lookup))
+	Ok((payment_id, sender, beneficiary, sender_lookup, beneficiary_lookup))
 }
 
 #[benchmarks(
@@ -81,7 +93,7 @@ mod benchmarks {
 
 	#[benchmark]
 	fn pay(q: Linear<1, { T::MaxRemarkLength::get() }>) -> Result<(), BenchmarkError> {
-		let (sender, beneficiary, beneficiary_lookup) = create_accounts::<T>();
+		let (sender, beneficiary, _, beneficiary_lookup) = create_accounts::<T>();
 		let asset: AssetIdOf<T> = <AssetIdOf<T>>::zero();
 		create_and_mint_asset::<T>(&sender, &beneficiary, &asset, &<BalanceOf<T>>::from(100000u32))?;
 		let amount = <BalanceOf<T>>::from(50_u32);
@@ -118,12 +130,147 @@ mod benchmarks {
 	fn release() -> Result<(), BenchmarkError> {
 		let amount = <BalanceOf<T>>::from(50_u32);
 		let asset = <AssetIdOf<T>>::zero();
-		let (payment_id, sender, beneficiary, beneficiary_lookup) = create_payment::<T>(&amount, &asset, None)?;
+		let (payment_id, sender, beneficiary, _, beneficiary_lookup) = create_payment::<T>(&amount, &asset, None)?;
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(sender.clone()), beneficiary_lookup, payment_id);
 
 		assert_last_event::<T>(Event::PaymentReleased { sender, beneficiary }.into());
+		Ok(())
+	}
+
+	#[benchmark]
+	fn cancel() -> Result<(), BenchmarkError> {
+		let amount = <BalanceOf<T>>::from(50_u32);
+		let asset = <AssetIdOf<T>>::zero();
+		let (payment_id, sender, beneficiary, sender_lookup, _beneficiary_lookup) =
+			create_payment::<T>(&amount, &asset, None)?;
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(beneficiary.clone()), sender_lookup, payment_id);
+
+		assert_last_event::<T>(Event::PaymentCancelled { sender, beneficiary }.into());
+		Ok(())
+	}
+
+	#[benchmark]
+	fn request_refund() -> Result<(), BenchmarkError> {
+		let amount = <BalanceOf<T>>::from(50_u32);
+		let asset = <AssetIdOf<T>>::zero();
+		let (payment_id, sender, beneficiary, _sender_lookup, beneficiary_lookup) =
+			create_payment::<T>(&amount, &asset, None)?;
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(sender.clone()), beneficiary_lookup, payment_id);
+
+		let current_block = frame_system::Pallet::<T>::block_number();
+		let expiry = current_block + T::CancelBufferBlockLength::get();
+
+		assert_last_event::<T>(
+			Event::PaymentCreatorRequestedRefund {
+				sender,
+				beneficiary,
+				expiry,
+			}
+			.into(),
+		);
+		Ok(())
+	}
+
+	#[benchmark]
+	fn dispute_refund() -> Result<(), BenchmarkError> {
+		let amount = <BalanceOf<T>>::from(50_u32);
+		let asset = <AssetIdOf<T>>::zero();
+		let (payment_id, sender, beneficiary, sender_lookup, beneficiary_lookup) =
+			create_payment::<T>(&amount, &asset, None)?;
+
+		assert!(Payments::<T>::request_refund(
+			RawOrigin::Signed(sender.clone()).into(),
+			beneficiary_lookup,
+			payment_id
+		)
+		.is_ok());
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(beneficiary.clone()), sender_lookup, payment_id);
+
+		assert_last_event::<T>(Event::PaymentRefundDisputed { sender, beneficiary }.into());
+		Ok(())
+	}
+
+	#[benchmark]
+	fn resolve_dispute() -> Result<(), BenchmarkError> {
+		let amount = <BalanceOf<T>>::from(50_u32);
+		let asset = <AssetIdOf<T>>::zero();
+		let (payment_id, sender, beneficiary, sender_lookup, beneficiary_lookup) =
+			create_payment::<T>(&amount, &asset, None)?;
+
+		assert!(Payments::<T>::request_refund(
+			RawOrigin::Signed(sender.clone()).into(),
+			beneficiary_lookup.clone(),
+			payment_id
+		)
+		.is_ok());
+
+		assert!(Payments::<T>::dispute_refund(
+			RawOrigin::Signed(beneficiary.clone()).into(),
+			sender_lookup.clone(),
+			payment_id
+		)
+		.is_ok());
+
+		let dispute_result = DisputeResult {
+			percent_beneficiary: Percent::from_percent(90),
+			in_favor_of: Role::Sender,
+		};
+
+		#[extrinsic_call]
+		_(
+			RawOrigin::Root,
+			sender_lookup,
+			beneficiary_lookup,
+			payment_id,
+			dispute_result,
+		);
+
+		assert_last_event::<T>(Event::PaymentDisputeResolved { sender, beneficiary }.into());
+		Ok(())
+	}
+
+	#[benchmark]
+	fn request_payment() -> Result<(), BenchmarkError> {
+		let (sender, beneficiary, sender_lookup, _beneficiary_lookup) = create_accounts::<T>();
+		let asset: AssetIdOf<T> = <AssetIdOf<T>>::zero();
+		create_and_mint_asset::<T>(&sender, &beneficiary, &asset, &<BalanceOf<T>>::from(100000u32))?;
+		let amount = <BalanceOf<T>>::from(50_u32);
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(beneficiary.clone()), sender_lookup, asset, amount);
+
+		assert_last_event::<T>(Event::PaymentRequestCreated { sender, beneficiary }.into());
+		Ok(())
+	}
+
+	#[benchmark]
+	fn accept_and_pay() -> Result<(), BenchmarkError> {
+		let (sender, beneficiary, sender_lookup, beneficiary_lookup) = create_accounts::<T>();
+		let asset: AssetIdOf<T> = <AssetIdOf<T>>::zero();
+		create_and_mint_asset::<T>(&sender, &beneficiary, &asset, &<BalanceOf<T>>::from(100000u32))?;
+		let amount = <BalanceOf<T>>::from(50_u32);
+		let payment_id: T::PaymentId = Payments::<T>::next_payment_id()?;
+
+		assert!(Payments::<T>::request_payment(
+			RawOrigin::Signed(beneficiary.clone()).into(),
+			sender_lookup,
+			asset,
+			amount
+		)
+		.is_ok());
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(sender.clone()), beneficiary_lookup, payment_id);
+
+		assert_last_event::<T>(Event::PaymentRequestCreated { sender, beneficiary }.into());
 		Ok(())
 	}
 

--- a/pallets/payments/src/benchmarking.rs
+++ b/pallets/payments/src/benchmarking.rs
@@ -24,6 +24,54 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
+fn create_accounts<T: Config>() -> (T::AccountId, T::AccountId, AccountIdLookupOf<T>) {
+	let sender: T::AccountId = account("Alice", 0, 1);
+	let beneficiary: T::AccountId = account("Bob", 0, 2);
+	let beneficiary_lookup = T::Lookup::unlookup(beneficiary.clone());
+	(sender, beneficiary, beneficiary_lookup)
+}
+
+fn create_and_mint_asset<T: Config>(
+	sender: &T::AccountId,
+	beneficiary: &T::AccountId,
+	asset: &AssetIdOf<T>,
+	amount: &BalanceOf<T>,
+) -> Result<(), BenchmarkError> {
+	T::BenchmarkHelper::create_asset(asset.clone(), sender.clone(), true, <BalanceOf<T>>::from(1u32));
+	T::Assets::mint_into(asset.clone(), &sender, <BalanceOf<T>>::from(100000u32))?;
+	T::Assets::mint_into(asset.clone(), &beneficiary, <BalanceOf<T>>::from(100000u32))?;
+
+	Ok(())
+}
+
+fn create_payment<T: Config>(
+	amount: &BalanceOf<T>,
+	asset: &AssetIdOf<T>,
+	remark: Option<BoundedDataOf<T>>,
+) -> Result<(T::PaymentId, T::AccountId, T::AccountId, AccountIdLookupOf<T>), BenchmarkError> {
+	let (sender, beneficiary, beneficiary_lookup) = create_accounts::<T>();
+	create_and_mint_asset::<T>(&sender, &beneficiary, &asset, &<BalanceOf<T>>::from(100000u32))?;
+
+	let payment_id: T::PaymentId = Payments::<T>::next_payment_id()?;
+
+	let payment_detail = Payments::<T>::create_payment(
+		&sender,
+		&beneficiary,
+		asset.clone(),
+		amount.clone(),
+		PaymentState::Created,
+		T::IncentivePercentage::get(),
+		remark.as_ref().map(|x| x.as_slice()),
+	)?;
+
+	// reserve funds for payment
+	Payments::<T>::reserve_payment_amount(&sender, &beneficiary, payment_detail)?;
+
+	// TODO: check storage items
+
+	Ok((payment_id, sender, beneficiary, beneficiary_lookup))
+}
+
 #[benchmarks(
 	where
 		<<T as Config>::Assets as Inspect<<T as frame_system::Config>::AccountId>>::AssetId: Zero,
@@ -33,11 +81,9 @@ mod benchmarks {
 
 	#[benchmark]
 	fn pay(q: Linear<1, { T::MaxRemarkLength::get() }>) -> Result<(), BenchmarkError> {
-		let sender: T::AccountId = account("Alice", 0, 1);
-		let beneficiary: T::AccountId = account("Bob", 0, 2);
-		T::BenchmarkHelper::set_balance(beneficiary.clone(), <BalanceOf<T>>::from(100_000_000_u32));
-		let beneficiary_lookup = T::Lookup::unlookup(beneficiary.clone());
-		let asset = <AssetIdOf<T>>::zero();
+		let (sender, beneficiary, beneficiary_lookup) = create_accounts::<T>();
+		let asset: AssetIdOf<T> = <AssetIdOf<T>>::zero();
+		create_and_mint_asset::<T>(&sender, &beneficiary, &asset, &<BalanceOf<T>>::from(100000u32))?;
 		let amount = <BalanceOf<T>>::from(50_u32);
 
 		let remark: Option<BoundedDataOf<T>> = if q == 0 {
@@ -45,9 +91,6 @@ mod benchmarks {
 		} else {
 			Some(BoundedVec::try_from(vec![1 as u8; q as usize]).unwrap())
 		};
-
-		T::BenchmarkHelper::create_asset(asset.clone(), sender.clone(), true, <BalanceOf<T>>::from(1u32));
-		T::Assets::mint_into(asset.clone(), &sender, <BalanceOf<T>>::from(100000u32))?;
 
 		#[extrinsic_call]
 		_(
@@ -68,6 +111,19 @@ mod benchmarks {
 			}
 			.into(),
 		);
+		Ok(())
+	}
+
+	#[benchmark]
+	fn release() -> Result<(), BenchmarkError> {
+		let amount = <BalanceOf<T>>::from(50_u32);
+		let asset = <AssetIdOf<T>>::zero();
+		let (payment_id, sender, beneficiary, beneficiary_lookup) = create_payment::<T>(&amount, &asset, None)?;
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(sender.clone()), beneficiary_lookup, payment_id);
+
+		assert_last_event::<T>(Event::PaymentReleased { sender, beneficiary }.into());
 		Ok(())
 	}
 

--- a/pallets/payments/src/benchmarking.rs
+++ b/pallets/payments/src/benchmarking.rs
@@ -13,13 +13,6 @@ use frame_support::{
 use frame_system::RawOrigin;
 use sp_runtime::Percent;
 
-const SEED: u32 = 1;
-
-// See if `generic_event` has been emitted.
-fn assert_has_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
-	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
-}
-
 // Compare `generic_event` to the last emitted event.
 fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());

--- a/pallets/payments/src/benchmarking.rs
+++ b/pallets/payments/src/benchmarking.rs
@@ -1,0 +1,73 @@
+use super::*;
+#[allow(unused)]
+use crate::{smart_logic::Rule::Promotion, smart_logic::*, types::*, Pallet as Cards};
+use frame_benchmarking::{account, v2::*};
+use frame_support::{
+	traits::{
+		fungibles::{Inspect, Mutate},
+		Get, UnixTime,
+	},
+	BoundedBTreeSet,
+};
+use frame_system::RawOrigin;
+use sp_arithmetic::{traits::Saturating, Percent};
+
+const SEED: u32 = 1;
+
+// See if `generic_event` has been emitted.
+fn assert_has_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
+}
+
+// Compare `generic_event` to the last emitted event.
+fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
+}
+
+fn generate_remark(q: u8) -> Option<Vec<u8>> {
+	if q == 0 {
+		None
+	} else {
+		Some(vec![0; q as usize])
+	}
+}
+
+fn origin<T: Config>(o: Origin) -> RawOrigin<T::AccountId> {
+	T::BenchmarkHelper::origin(o)
+}
+
+#[benchmarks(
+	where
+		<<T as Config>::Assets as Inspect<<T as frame_system::Config>::AccountId>>::AssetId: Zero,
+)]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn pay(q: Linear<1, { T::MaxRemarkLength::get() }>) -> Result<(), BenchmarkError> {
+		let sender: T::AccountId = account("Alice", 0, 1);
+		let beneficiary: T::AccountId = account("Bob", 0, 2);
+		let asset = <AssetIdOf<T>>::zero();
+		let amount = <BalanceOf<T>>::from(50u32);
+		let remark = generate_remark(q.into());
+		T::BenchmarkHelper::create_asset(asset, sender, true, <BalanceOf<T>>::from(100u8));
+		T::Assets::mint_into(asset, &sender, 50_000_000_u32.into())?;
+
+		#[extrinsic_call]
+		_(origin::<T>(RawOrigin::Signed(SEED)), beneficiary, asset, amount, remark);
+
+		assert_last_event::<T>(
+			Event::PaymentCreated {
+				sender,
+				beneficiary,
+				asset,
+				amount,
+				remark,
+			}
+			.into(),
+		);
+		Ok(())
+	}
+
+	impl_benchmark_test_suite!(Payments, crate::mock::new_test_ext(), crate::mock::Test);
+}

--- a/pallets/payments/src/lib.rs
+++ b/pallets/payments/src/lib.rs
@@ -220,6 +220,11 @@ pub mod pallet {
 			sender: T::AccountId,
 			beneficiary: T::AccountId,
 		},
+		/// Payment disputed resolved
+		PaymentDisputeResolved {
+			sender: T::AccountId,
+			beneficiary: T::AccountId,
+		},
 	}
 
 	#[pallet::error]
@@ -485,7 +490,7 @@ pub mod pallet {
 			let dispute = Some((dispute_result, dispute_resolver));
 			Self::settle_payment(&sender, &beneficiary, &payment_id, dispute)?;
 
-			Self::deposit_event(Event::PaymentRefundDisputed { sender, beneficiary });
+			Self::deposit_event(Event::PaymentDisputeResolved { sender, beneficiary });
 			Ok(().into())
 		}
 

--- a/pallets/payments/src/lib.rs
+++ b/pallets/payments/src/lib.rs
@@ -52,6 +52,12 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	use sp_runtime::{traits::Get, Percent};
+
+	#[cfg(feature = "runtime-benchmarks")]
+	pub trait BenchmarkHelper<AccountId, AssetId, Balance> {
+		fn create_asset(id: AssetId, admin: AccountId, is_sufficient: bool, min_balance: Balance);
+	}
+
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;

--- a/pallets/payments/src/lib.rs
+++ b/pallets/payments/src/lib.rs
@@ -6,6 +6,9 @@ use frame_system::pallet_prelude::BlockNumberFor;
 /// <https://docs.substrate.io/v3/runtime/frame>
 pub use pallet::*;
 
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
 #[cfg(test)]
 mod mock;
 
@@ -133,6 +136,9 @@ pub mod pallet {
 		/// canceled payment
 		#[pallet::constant]
 		type CancelBufferBlockLength: Get<BlockNumberFor<Self>>;
+
+		#[cfg(feature = "runtime-benchmarks")]
+		type BenchmarkHelper: BenchmarkHelper<AccountIdOf<Self>, AssetIdOf<Self>, BalanceOf<Self>>;
 	}
 
 	#[pallet::pallet]

--- a/pallets/payments/src/mock.rs
+++ b/pallets/payments/src/mock.rs
@@ -17,7 +17,7 @@ use sp_runtime::{
 
 type Block = frame_system::mocking::MockBlock<Test>;
 type AccountId = u64;
-#[warn(dead_code)]
+#[allow(unused)]
 type AssetId = u32;
 
 pub const SENDER_ACCOUNT: AccountId = 10;
@@ -231,7 +231,7 @@ impl super::BenchmarkHelper<AccountId, AssetId, Balance> for BenchmarkHelper {
 }
 
 parameter_types! {
-	pub const MaxRemarkLength: u32 = 50;
+	pub const MaxRemarkLength: u8 = 50;
 	pub const IncentivePercentage: Percent = Percent::from_percent(INCENTIVE_PERCENTAGE);
 	pub const PaymentPalletId: PalletId = PalletId(*b"payments");
 }
@@ -254,6 +254,8 @@ impl pallet_payments::Config for Test {
 	type Preimages = ();
 	type CancelBufferBlockLength = ConstU64<10>;
 	type PalletsOrigin = OriginCaller;
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = BenchmarkHelper;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/payments/src/mock.rs
+++ b/pallets/payments/src/mock.rs
@@ -17,6 +17,8 @@ use sp_runtime::{
 
 type Block = frame_system::mocking::MockBlock<Test>;
 type AccountId = u64;
+#[warn(dead_code)]
+type AssetId = u32;
 
 pub const SENDER_ACCOUNT: AccountId = 10;
 pub const PAYMENT_BENEFICIARY: AccountId = 11;
@@ -210,6 +212,21 @@ impl crate::types::FeeHandler<Test> for MockFeeHandler {
 			sender_pays: compute_fee(&sender_fees),
 			beneficiary_pays: compute_fee(&beneficiary_fees),
 		}
+	}
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+pub struct BenchmarkHelper;
+#[cfg(feature = "runtime-benchmarks")]
+impl super::BenchmarkHelper<AccountId, AssetId, Balance> for BenchmarkHelper {
+	fn create_asset(id: AssetId, admin: AccountId, is_sufficient: bool, min_balance: Balance) {
+		<Assets as frame_support::traits::tokens::fungibles::Create<AccountId>>::create(
+			id,
+			admin,
+			is_sufficient,
+			min_balance,
+		)
+		.unwrap();
 	}
 }
 

--- a/runtime/kreivo/Cargo.toml
+++ b/runtime/kreivo/Cargo.toml
@@ -170,6 +170,7 @@ runtime-benchmarks = [
 	"pallet-burner/runtime-benchmarks",
 	"pallet-multisig/runtime-benchmarks",
 	"pallet-utility/runtime-benchmarks",
+	"pallet-payments/runtime-benchmarks",
 	"pallet-proxy/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",


### PR DESCRIPTION
This PR adds the benchmarking for all the extrinsics defined in the pallet.

Here the successful test executions:

```
➜  virto-node git:(feat-add-benchmarks-payments)  cargo test --package pallet-payments --features runtime-benchmarks
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on build directory
   Compiling pallet-payments v0.1.0 (/Users/hectorb/side/dark/virto-node/pallets/payments)
    Finished test [unoptimized] target(s) in 7.70s
     Running unittests src/lib.rs (target/debug/deps/pallet_payments-f80d3ba3c5e8ade5)

running 8 tests
test tests::payment_refunded_request ... ok
test tests::request_payment ... ok
test mock::__construct_runtime_integrity_test::runtime_integrity_tests ... ok
test tests::test_pay_and_cancel_works ... ok
test tests::test_pay_and_release_works ... ok
test tests::payment_disputed_sender_wins ... ok
test tests::payment_disputed_beneficiary_wins ... ok
test benchmarking::benchmarks::benchmark_tests::test_benchmarks ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

   Doc-tests pallet-payments

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Please note that benchmarks cannot be executed until the task #309 is not completed.