### PR TITLE
WIP: Extend dispatch options

### DIFF
--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -20,14 +20,14 @@ use frame_support::{
 		fungible::{Mutate, MutateFreeze},
 		fungibles::{InspectHold, MutateHold},
 		tokens::Precision,
-		Polling,
+		Polling, QueryPreimage,
 	},
 };
 use sp_runtime::{
 	traits::{AccountIdConversion, Dispatchable},
 	DispatchResultWithInfo, TokenError,
 };
-use sp_std::{vec, vec::Vec};
+use sp_std::vec::Vec;
 
 impl<T: Config> Pallet<T> {
 	#[inline]
@@ -208,14 +208,14 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	pub(crate) fn do_dispatch_as_community_account(
+	pub(crate) fn do_dispatch_as(
 		community_id: &CommunityIdOf<T>,
 		call: BoundedCallOf<T>,
 	) -> DispatchResultWithInfo<PostDispatchInfo> {
 		let community_account = Self::community_account(community_id);
 		let signer = frame_system::RawOrigin::Signed(community_account);
 
-		let _ = T::Preimages::realize(call);
+		let (call, _) = T::Preimages::realize(&call)?;
 		let post = call.dispatch(signer.into()).map_err(|e| e.error)?;
 		Ok(post)
 	}

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -1,4 +1,16 @@
+// <<<<<<< Updated upstream
+use self::types::BoundedCallOf;
 use super::{origin::DecisionMethod, *};
+// =======
+// use crate::{
+// 	origin::DecisionMethod,
+// 	types::{
+// 		AccountIdOf, BoundedCallOf, CommunityIdOf, CommunityInfo, CommunityState, ConstSizedField, MembershipIdOf,
+// 		PalletsOriginOf, PollIndexOf, RuntimeCallFor, Tally, Vote, VoteOf, VoteWeight,
+// 	},
+// 	CommunityDecisionMethod, CommunityIdFor, CommunityVotes, Config, Error, HoldReason, Info, Metadata, Pallet,
+// };
+// >>>>>>> Stashed changes
 use fc_traits_memberships::{GenericRank, Inspect, Rank};
 use frame_support::{
 	dispatch::PostDispatchInfo,
@@ -198,11 +210,12 @@ impl<T: Config> Pallet<T> {
 
 	pub(crate) fn do_dispatch_as_community_account(
 		community_id: &CommunityIdOf<T>,
-		call: RuntimeCallFor<T>,
+		call: BoundedCallOf<T>,
 	) -> DispatchResultWithInfo<PostDispatchInfo> {
 		let community_account = Self::community_account(community_id);
 		let signer = frame_system::RawOrigin::Signed(community_account);
 
+		let _ = T::Preimages::realize(call);
 		let post = call.dispatch(signer.into()).map_err(|e| e.error)?;
 		Ok(post)
 	}

--- a/pallets/communities/src/mock.rs
+++ b/pallets/communities/src/mock.rs
@@ -424,10 +424,12 @@ impl pallet_communities::Config for Test {
 	type Balances = Balances;
 	type MemberMgmt = Nfts;
 	type Polls = Referenda;
+	type Preimages = Preimage;
 
 	type CreateOrigin = EitherOf<RootCreatesCommunitiesForFree, AnyoneElsePays>;
 	type AdminOrigin = EnsureCommunity<Self>;
 	type MemberMgmtOrigin = EnsureCommunity<Self>;
+	type DispatchOrigin = EnsureCommunity<Self>;
 
 	type RuntimeCall = RuntimeCall;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/pallets/communities/src/tests/weights.rs
+++ b/pallets/communities/src/tests/weights.rs
@@ -30,7 +30,7 @@ fn weights() {
 		("vote", SubstrateWeight::<Test>::vote()),
 		("remove_vote", SubstrateWeight::<Test>::remove_vote()),
 		("unlock", SubstrateWeight::<Test>::unlock()),
-		("dispatch_as_account", SubstrateWeight::<Test>::dispatch_as_account()),
+		("dispatch_as", SubstrateWeight::<Test>::dispatch_as()),
 	] {
 		println!("{function}: {weight:?}",);
 		println!(

--- a/pallets/communities/src/types.rs
+++ b/pallets/communities/src/types.rs
@@ -1,4 +1,4 @@
-use crate::origin::DecisionMethod;
+use crate::origin::{DecisionMethod, RawOrigin};
 use crate::{CommunityDecisionMethod, Config};
 use fc_traits_memberships::{Inspect, Rank};
 use frame_support::{
@@ -139,6 +139,13 @@ impl<T: Config> Tally<T> {
 pub enum LockUpdateType {
 	Add,
 	Remove,
+}
+
+/// Target within the community the management origin can impersonate
+#[derive(Clone, Debug, Decode, Encode, MaxEncodedLen, PartialEq, TypeInfo)]
+pub enum DispatchTarget<C, M> {
+	Account(Option<u8>),
+	Origin(RawOrigin<C, M>),
 }
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/pallets/communities/src/types.rs
+++ b/pallets/communities/src/types.rs
@@ -1,11 +1,13 @@
 use crate::origin::DecisionMethod;
 use crate::{CommunityDecisionMethod, Config};
 use fc_traits_memberships::{Inspect, Rank};
-use frame_support::pallet_prelude::*;
-use frame_support::traits::{
-	fungible::{self, Inspect as FunInspect},
-	fungibles::{self, Inspect as FunsInspect},
-	Polling,
+use frame_support::{
+	pallet_prelude::*,
+	traits::{
+		fungible::{self, Inspect as FunInspect},
+		fungibles::{self, Inspect as FunsInspect},
+		Bounded, Polling,
+	},
 };
 use sp_runtime::traits::{StaticLookup, UniqueSaturatedInto};
 use sp_runtime::SaturatedConversion;
@@ -24,6 +26,7 @@ pub type PalletsOriginOf<T> =
 pub type MembershipIdOf<T> = <T as Config>::MembershipId;
 pub type RuntimeCallFor<T> = <T as Config>::RuntimeCall;
 pub type RuntimeOriginFor<T> = <T as Config>::RuntimeOrigin;
+pub type BoundedCallOf<T> = Bounded<<T as Config>::RuntimeCall, <T as frame_system::Config>::Hashing>;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub type BenchmarkHelperOf<T> = <T as Config>::BenchmarkHelper;

--- a/pallets/communities/src/weights.rs
+++ b/pallets/communities/src/weights.rs
@@ -43,7 +43,7 @@ pub trait WeightInfo {
 	fn vote() -> Weight;
 	fn remove_vote() -> Weight;
 	fn unlock() -> Weight;
-	fn dispatch_as_account() -> Weight;
+	fn dispatch_as() -> Weight;
 }
 
 /// Weights for pallet_communities using the Substrate node and recommended hardware.
@@ -254,7 +254,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	/// Storage: `Communities::Info` (r:1 w:0)
 	/// Proof: `Communities::Info` (`max_values`: None, `max_size`: Some(19), added: 2494, mode: `MaxEncodedLen`)
-	fn dispatch_as_account() -> Weight {
+	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `115`
 		//  Estimated: `3484`
@@ -472,7 +472,7 @@ impl WeightInfo for () {
 	}
 	/// Storage: `Communities::Info` (r:1 w:0)
 	/// Proof: `Communities::Info` (`max_values`: None, `max_size`: Some(19), added: 2494, mode: `MaxEncodedLen`)
-	fn dispatch_as_account() -> Weight {
+	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `115`
 		//  Estimated: `3484`

--- a/runtime/kreivo/src/weights/pallet_communities.rs
+++ b/runtime/kreivo/src/weights/pallet_communities.rs
@@ -253,7 +253,7 @@ impl<T: frame_system::Config> pallet_communities::WeightInfo for WeightInfo<T> {
 	}
 	/// Storage: `Communities::Info` (r:1 w:0)
 	/// Proof: `Communities::Info` (`max_values`: None, `max_size`: Some(19), added: 2494, mode: `MaxEncodedLen`)
-	fn dispatch_as_account() -> Weight {
+	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `115`
 		//  Estimated: `3484`


### PR DESCRIPTION
Add support to more dispatch options to allow for sub-origins and sub-accounts, besides the main community origin and account.
Also use a bounded call to allow dispatching existing preimages.