### PR TITLE
Automatically create the asset of a community if it doesnt exist yet

### DIFF
--- a/pallets/communities/src/benchmarking.rs
+++ b/pallets/communities/src/benchmarking.rs
@@ -3,18 +3,17 @@
 use super::*;
 
 use self::{
-	origin::DecisionMethod,
 	types::{
 		AccountIdOf, AssetIdOf, CommunityIdOf, DecisionMethodFor, MembershipIdOf, NativeBalanceOf, PalletsOriginOf,
 		PollIndexOf, RuntimeCallFor, Vote,
 	},
-	CommunityDecisionMethod, Event, HoldReason, Pallet as Communities,
+	CommunityDecisionMethod, DecisionMethod, Event, HoldReason, Pallet as Communities,
 };
 use fc_traits_memberships::{Inspect, Rank};
 use frame_benchmarking::v2::*;
 use frame_support::traits::{
 	fungible::{InspectFreeze, Mutate},
-	fungibles::{Create, Mutate as FunsMutate},
+	fungibles::Mutate as FunsMutate,
 	OriginTrait,
 };
 use frame_system::{
@@ -197,7 +196,7 @@ mod benchmarks {
 		_(
 			admin_origin,
 			id,
-			DecisionMethod::CommunityAsset(T::BenchmarkHelper::community_asset_id()),
+			DecisionMethod::CommunityAsset(T::BenchmarkHelper::community_asset_id(), 10u128.into()),
 		);
 
 		// verification code
@@ -316,7 +315,7 @@ mod benchmarks {
 		// setup code
 		let (id, origin) = create_community::<T>(
 			RawOrigin::Root.into(),
-			Some(DecisionMethodFor::<T>::CommunityAsset(1u32.into())),
+			Some(DecisionMethodFor::<T>::CommunityAsset(1u32.into(), 1u128.into())),
 		)?;
 		let members = setup_members::<T>(origin.clone(), id)?;
 
@@ -325,9 +324,6 @@ mod benchmarks {
 			.expect("desired size of community to be equal or greather than 1")
 			.clone();
 
-		let community_account = Communities::<T>::community_account(&id);
-
-		T::Assets::create(1u32.into(), community_account, false, 1u128.into())?;
 		T::Assets::mint_into(1u32.into(), &who, 4u128.into())?;
 
 		prepare_track_and_prepare_poll::<T>(origin.into_caller(), who.clone())?;

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -96,7 +96,7 @@ impl<T: Config> Pallet<T> {
 
 			let say = *match (vote, decision_method) {
 				(Vote::AssetBalance(say, asset, amount), DecisionMethod::CommunityAsset(a, min)) if asset == a => {
-					ensure!(amount > min, Error::<T>::VoteBelowMinimum);
+					ensure!(amount >= min, Error::<T>::VoteBelowMinimum);
 					say
 				}
 				(Vote::NativeBalance(say, ..), DecisionMethod::NativeToken)

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -1,4 +1,4 @@
-use super::{origin::DecisionMethod, *};
+use super::*;
 use fc_traits_memberships::{GenericRank, Inspect, Rank};
 use frame_support::{
 	dispatch::PostDispatchInfo,
@@ -95,7 +95,10 @@ impl<T: Config> Pallet<T> {
 			};
 
 			let say = *match (vote, decision_method) {
-				(Vote::AssetBalance(say, asset, ..), DecisionMethod::CommunityAsset(a)) if asset == a => say,
+				(Vote::AssetBalance(say, asset, amount), DecisionMethod::CommunityAsset(a, min)) if asset == a => {
+					ensure!(amount > min, Error::<T>::VoteBelowMinimum);
+					say
+				}
 				(Vote::NativeBalance(say, ..), DecisionMethod::NativeToken)
 				| (Vote::Standard(say), DecisionMethod::Membership | DecisionMethod::Rank) => say,
 				_ => fail!(Error::<T>::InvalidVoteType),

--- a/pallets/communities/src/mock.rs
+++ b/pallets/communities/src/mock.rs
@@ -24,8 +24,9 @@ pub use virto_common::{CommunityId, MembershipId};
 
 use crate::{
 	self as pallet_communities,
-	origin::{DecisionMethod, EnsureCommunity, EnsureSignedPays},
+	origin::{EnsureCommunity, EnsureSignedPays},
 	types::{Tally, VoteWeight},
+	DecisionMethod,
 };
 
 // Weights constants
@@ -455,7 +456,7 @@ pub(crate) struct TestEnvBuilder {
 	assets_config: AssetsConfig,
 	balances: Vec<(AccountId, Balance)>,
 	communities: Vec<CommunityId>,
-	decision_methods: sp_std::collections::btree_map::BTreeMap<CommunityId, DecisionMethod<AssetId>>,
+	decision_methods: sp_std::collections::btree_map::BTreeMap<CommunityId, DecisionMethod<AssetId, Balance>>,
 	members: Vec<(CommunityId, AccountId)>,
 	memberships: Vec<(CommunityId, MembershipId)>,
 	tracks: Vec<(TrackIdOf<Test, ()>, TrackInfoOf<Test>)>,
@@ -498,7 +499,7 @@ impl TestEnvBuilder {
 	pub(crate) fn add_community(
 		mut self,
 		community_id: CommunityId,
-		decision_method: DecisionMethod<AssetId>,
+		decision_method: DecisionMethod<AssetId, Balance>,
 		members: &[AccountId],
 		memberships: &[MembershipId],
 		maybe_track: Option<TrackInfoOf<Test>>,

--- a/pallets/communities/src/origin.rs
+++ b/pallets/communities/src/origin.rs
@@ -126,16 +126,6 @@ pub enum Subset<T: Config> {
 	AtLeastRank(GenericRank),
 }
 
-/// The mechanism used by the community or one of its subsets to make decisions
-#[derive(Clone, Debug, Decode, Default, Encode, Eq, MaxEncodedLen, PartialEq, TypeInfo)]
-pub enum DecisionMethod<AssetId> {
-	#[default]
-	Membership,
-	NativeToken,
-	CommunityAsset(AssetId),
-	Rank,
-}
-
 #[cfg(feature = "xcm")]
 impl<T> TryConvert<RuntimeOriginFor<T>, xcm::v3::MultiLocation> for RawOrigin<T>
 where

--- a/pallets/communities/src/tests/governance.rs
+++ b/pallets/communities/src/tests/governance.rs
@@ -6,9 +6,8 @@ use parity_scale_codec::Encode;
 use sp_runtime::{str_array as s, BoundedVec, TokenError};
 
 use crate::{
-	origin::DecisionMethod,
 	types::{Tally, Vote},
-	Call,
+	Call, DecisionMethod,
 };
 use frame_support::assert_noop;
 use pallet_referenda::TrackInfo;
@@ -108,7 +107,7 @@ fn new_test_ext() -> sp_io::TestExternalities {
 		// Community-asset based
 		.add_community(
 			COMMUNITY_B,
-			DecisionMethod::CommunityAsset(COMMUNITY_B_ASSET_ID),
+			DecisionMethod::CommunityAsset(COMMUNITY_B_ASSET_ID, 10),
 			&[BOB, CHARLIE],
 			memberships_of(COMMUNITY_B),
 			Some(CommunityTrack::get()),
@@ -119,7 +118,7 @@ fn new_test_ext() -> sp_io::TestExternalities {
 			true,
 			1,
 			None,
-			Some(vec![(BOB, 10), (CHARLIE, 10)]),
+			Some(vec![(BOB, 50), (CHARLIE, 50)]),
 		)
 		// Native-asset based
 		.add_community(
@@ -210,7 +209,7 @@ mod vote {
 						1,
 						Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 0)
 					),
-					TokenError::BelowMinimum
+					Error::VoteBelowMinimum
 				);
 			});
 		}
@@ -537,10 +536,31 @@ mod vote {
 						RuntimeOrigin::signed(CHARLIE),
 						membership(COMMUNITY_B, 2),
 						1,
-						Vote::AssetBalance(false, COMMUNITY_B_ASSET_ID, 10)
+						Vote::AssetBalance(false, COMMUNITY_B_ASSET_ID, 50)
 					),
 					TokenError::FundsUnavailable
 				);
+			});
+		}
+
+		#[test]
+		fn fails_if_asset_vote_weight_is_under_minimum() {
+			new_test_ext().execute_with(|| {
+				assert_noop!(
+					Communities::vote(
+						RuntimeOrigin::signed(BOB),
+						membership(COMMUNITY_B, 1),
+						1,
+						Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 10)
+					),
+					Error::VoteBelowMinimum
+				);
+				assert_ok!(Communities::vote(
+					RuntimeOrigin::signed(BOB),
+					membership(COMMUNITY_B, 1),
+					1,
+					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 11)
+				));
 			});
 		}
 
@@ -552,7 +572,7 @@ mod vote {
 					COMMUNITY_B_ASSET_ID,
 					&pallet_preimage::HoldReason::Preimage.into(),
 					&CHARLIE,
-					6,
+					40,
 				));
 
 				// Before voting, the poll is ongoing
@@ -561,7 +581,7 @@ mod vote {
 						RuntimeOrigin::signed(CHARLIE),
 						membership(COMMUNITY_B, 2),
 						1,
-						Vote::AssetBalance(false, COMMUNITY_B_ASSET_ID, 5)
+						Vote::AssetBalance(false, COMMUNITY_B_ASSET_ID, 15)
 					),
 					TokenError::FundsUnavailable
 				);
@@ -589,7 +609,7 @@ mod vote {
 					RuntimeOrigin::signed(BOB),
 					membership(COMMUNITY_B, 1),
 					1,
-					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 6)
+					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 30)
 				));
 
 				tick_block();
@@ -598,7 +618,7 @@ mod vote {
 					RuntimeOrigin::signed(CHARLIE),
 					membership(COMMUNITY_B, 2),
 					1,
-					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 6)
+					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 30)
 				));
 
 				tick_block();
@@ -611,9 +631,9 @@ mod vote {
 					pallet_referenda::Event::<Test>::Confirmed {
 						index: 1,
 						tally: Tally {
-							ayes: 12,
+							ayes: 60,
 							nays: 0,
-							bare_ayes: 12,
+							bare_ayes: 60,
 							..Default::default()
 						},
 					}
@@ -643,7 +663,7 @@ mod vote {
 					RuntimeOrigin::signed(BOB),
 					membership(COMMUNITY_B, 1),
 					1,
-					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 2)
+					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 12)
 				));
 
 				tick_block();
@@ -652,7 +672,7 @@ mod vote {
 					RuntimeOrigin::signed(CHARLIE),
 					membership(COMMUNITY_B, 2),
 					1,
-					Vote::AssetBalance(false, COMMUNITY_B_ASSET_ID, 1)
+					Vote::AssetBalance(false, COMMUNITY_B_ASSET_ID, 11)
 				));
 
 				tick_blocks(4);
@@ -665,9 +685,9 @@ mod vote {
 					pallet_referenda::Event::<Test>::Confirmed {
 						index: 1,
 						tally: Tally {
-							ayes: 2,
-							nays: 1,
-							bare_ayes: 2,
+							ayes: 12,
+							nays: 11,
+							bare_ayes: 12,
 							..Default::default()
 						},
 					}
@@ -699,7 +719,7 @@ mod vote {
 					RuntimeOrigin::signed(CHARLIE),
 					membership(COMMUNITY_B, 2),
 					1,
-					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 6)
+					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 11)
 				));
 
 				tick_block();
@@ -708,7 +728,7 @@ mod vote {
 					RuntimeOrigin::signed(BOB),
 					membership(COMMUNITY_B, 1),
 					1,
-					Vote::AssetBalance(false, COMMUNITY_B_ASSET_ID, 7)
+					Vote::AssetBalance(false, COMMUNITY_B_ASSET_ID, 12)
 				));
 
 				tick_block();
@@ -717,7 +737,7 @@ mod vote {
 					RuntimeOrigin::signed(CHARLIE),
 					membership(COMMUNITY_B, 2),
 					1,
-					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 8)
+					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 13)
 				));
 
 				tick_blocks(3);
@@ -726,9 +746,9 @@ mod vote {
 					pallet_referenda::Event::<Test>::Confirmed {
 						index: 1,
 						tally: Tally {
-							ayes: 8,
-							nays: 7,
-							bare_ayes: 8,
+							ayes: 13,
+							nays: 12,
+							bare_ayes: 13,
 							..Default::default()
 						},
 					}
@@ -1156,7 +1176,7 @@ mod unlock {
 				RuntimeOrigin::signed(BOB),
 				membership(COMMUNITY_B, 1),
 				1,
-				Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 9)
+				Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 15)
 			));
 
 			assert_ok!(Communities::vote(

--- a/pallets/communities/src/tests/governance.rs
+++ b/pallets/communities/src/tests/governance.rs
@@ -551,7 +551,7 @@ mod vote {
 						RuntimeOrigin::signed(BOB),
 						membership(COMMUNITY_B, 1),
 						1,
-						Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 10)
+						Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 9)
 					),
 					Error::VoteBelowMinimum
 				);
@@ -559,7 +559,7 @@ mod vote {
 					RuntimeOrigin::signed(BOB),
 					membership(COMMUNITY_B, 1),
 					1,
-					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 11)
+					Vote::AssetBalance(true, COMMUNITY_B_ASSET_ID, 10)
 				));
 			});
 		}


### PR DESCRIPTION
closes #396

The main change besides registering an asset optimistically when setting the decision method is to add the MinVote parameter to determine if an asset vote is too low and to also use the parameter as the minimum balance of the newly created asset.