### PR TITLE
Enforce setting a first admin when creating a community

### DIFF
--- a/pallets/communities-manager/src/benchmarking.rs
+++ b/pallets/communities-manager/src/benchmarking.rs
@@ -40,15 +40,14 @@ mod benchmarks {
 		setup_account::<T>(&first_member)?;
 
 		let community_id: CommunityIdOf<T> = 1.into();
-		let admin_origin: RuntimeOriginFor<T> = frame_system::Origin::<T>::Signed(first_member.clone()).into();
-		let admin_origin_caller: PalletsOriginOf<T> = admin_origin.into_caller();
+		let first_admin = T::Lookup::unlookup(first_member.clone());
 
 		#[extrinsic_call]
 		_(
 			RawOrigin::Root,
 			community_id,
 			BoundedVec::truncate_from(b"Test Community".into()),
-			Some(admin_origin_caller.clone()),
+			first_admin,
 			None,
 			None,
 		);


### PR DESCRIPTION
This resolves the issue of arbitrarily setting an origin that may not be controlled by an account, which is necessary, in first instance, to setup the initial members of a community.

This change implies changes in documentation (including, but not limited to existing tutorials and articles).