### PR TITLE
feat(kreivo-runtime): Receive valid assets from XCM, and (if these pass the barriers) create an asset class when not existing in the runtime

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 mod multilocation_asset_id;
 mod payment_id;
 
-pub use multilocation_asset_id::{FungibleAssetLocation, NetworkId};
+pub use multilocation_asset_id::{FungibleAssetLocation, NetworkId, Para};
 pub use payment_id::PaymentId;
 
 #[cfg(feature = "runtime")]

--- a/common/src/multilocation_asset_id.rs
+++ b/common/src/multilocation_asset_id.rs
@@ -26,9 +26,9 @@ pub enum FungibleAssetLocation {
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Para {
-	id: u16,
-	pallet: u8,
-	index: u32,
+	pub id: u16,
+	pub pallet: u8,
+	pub index: u32,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/runtime/kreivo/src/xcm_config.rs
+++ b/runtime/kreivo/src/xcm_config.rs
@@ -33,6 +33,8 @@ use xcm_executor::traits::JustTry;
 use xcm_executor::XcmExecutor;
 
 mod communities;
+mod with_external_assets;
+
 use communities::*;
 
 #[cfg(not(feature = "paseo"))]
@@ -101,7 +103,7 @@ pub type FungibleTransactor = FungibleAdapter<
 >;
 
 /// Means for transacting assets besides the native currency on this chain.
-pub type FungiblesTransactor = FungiblesAdapter<
+pub type FungiblesTransactor = with_external_assets::FungiblesAdapterForExternalAssets<
 	// Use this fungibles implementation:
 	Assets,
 	// Use this currency when it is a registered fungible asset matching the given location or name
@@ -116,6 +118,8 @@ pub type FungiblesTransactor = FungiblesAdapter<
 	LocalMint<parachains_common::impls::NonZeroIssuance<AccountId, Assets>>,
 	// The account to use for tracking teleports.
 	CheckingAccount,
+	// The account who owns the newly created assets
+	TreasuryAccount,
 >;
 
 /// This is the type we use to convert an (incoming) XCM origin into a local

--- a/runtime/kreivo/src/xcm_config/with_external_assets.rs
+++ b/runtime/kreivo/src/xcm_config/with_external_assets.rs
@@ -1,0 +1,104 @@
+use super::*;
+use core::fmt::Debug;
+use frame_support::traits::fungibles;
+use xcm_builder::AssetChecking;
+use xcm_executor::traits::{ConvertLocation, MatchesFungibles, TransactAsset};
+
+pub struct FungiblesAdapterForExternalAssets<
+	Assets,
+	Matcher,
+	AccountIdConverter,
+	AccountId,
+	CheckAsset,
+	CheckingAccount,
+	NewAssetsOwner,
+>(
+	PhantomData<(
+		Assets,
+		Matcher,
+		AccountIdConverter,
+		AccountId,
+		CheckAsset,
+		CheckingAccount,
+		NewAssetsOwner,
+	)>,
+);
+
+impl<
+		Assets: fungibles::Mutate<AccountId> + fungibles::Create<AccountId>,
+		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
+		AccountIdConverter: ConvertLocation<AccountId>,
+		AccountId: Eq + Clone + Debug, /* can't get away without it since Currency is generic over it. */
+		CheckAsset: AssetChecking<Assets::AssetId>,
+		CheckingAccount: Get<AccountId>,
+		NewAssetsOwner: Get<AccountId>,
+	> TransactAsset
+	for FungiblesAdapterForExternalAssets<
+		Assets,
+		Matcher,
+		AccountIdConverter,
+		AccountId,
+		CheckAsset,
+		CheckingAccount,
+		NewAssetsOwner,
+	>
+{
+	fn can_check_in(origin: &Location, what: &Asset, context: &XcmContext) -> XcmResult {
+		FungiblesAdapter::<Assets, Matcher, AccountIdConverter, AccountId, CheckAsset, CheckingAccount>::can_check_in(
+			origin, what, context,
+		)
+	}
+
+	fn check_in(origin: &Location, what: &Asset, context: &XcmContext) {
+		FungiblesAdapter::<Assets, Matcher, AccountIdConverter, AccountId, CheckAsset, CheckingAccount>::check_in(
+			origin, what, context,
+		)
+	}
+
+	fn can_check_out(dest: &Location, what: &Asset, context: &XcmContext) -> XcmResult {
+		FungiblesAdapter::<Assets, Matcher, AccountIdConverter, AccountId, CheckAsset, CheckingAccount>::can_check_out(
+			dest, what, context,
+		)
+	}
+
+	fn check_out(dest: &Location, what: &Asset, context: &XcmContext) {
+		FungiblesAdapter::<Assets, Matcher, AccountIdConverter, AccountId, CheckAsset, CheckingAccount>::check_out(
+			dest, what, context,
+		)
+	}
+
+	fn deposit_asset(what: &Asset, who: &Location, context: Option<&XcmContext>) -> XcmResult {
+		let (asset_id, _) = Matcher::matches_fungibles(what)?;
+
+		if !Assets::asset_exists(asset_id.clone()) {
+			Assets::create(asset_id, NewAssetsOwner::get(), false, 1u32.into()).map_err(|_| XcmError::AssetNotFound)?;
+		}
+
+		FungiblesAdapter::<Assets, Matcher, AccountIdConverter, AccountId, CheckAsset, CheckingAccount>::deposit_asset(
+			what, who, context,
+		)
+	}
+
+	fn withdraw_asset(
+		what: &Asset,
+		who: &Location,
+		maybe_context: Option<&XcmContext>,
+	) -> Result<xcm_executor::AssetsInHolding, XcmError> {
+		FungiblesAdapter::<Assets, Matcher, AccountIdConverter, AccountId, CheckAsset, CheckingAccount>::withdraw_asset(
+			what,
+			who,
+			maybe_context,
+		)
+	}
+
+	fn internal_transfer_asset(
+		what: &Asset,
+		from: &Location,
+		to: &Location,
+		context: &XcmContext,
+	) -> Result<xcm_executor::AssetsInHolding, XcmError> {
+		FungiblesAdapter::<Assets, Matcher, AccountIdConverter, AccountId, CheckAsset, CheckingAccount>::internal_transfer_asset(
+			what, from, to, context
+		)
+	}
+}


### PR DESCRIPTION
This pull request handles the creation of asset classes on the `Assets` pallet if these are accepted by the barriers, and don't exist on the pallet registry, so they can be imported into Kreivo without having to handle a proposal for each new added asset.